### PR TITLE
fix: PD-5386 Do not update global AWS config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,11 @@ var utils = require("./utils");
 
 global.__basePath = process.env.PWD;
 
-module.exports = function(awsconfig, dynamodboptions) {
+module.exports = function(dynamoDbOptions) {
 
 	"use strict";
 
-	AWS.config.update(awsconfig);
-
-	var dynamodb = new AWS.DynamoDB(dynamodboptions);
+	var dynamodb = new AWS.DynamoDB(dynamoDbOptions);
 
 	var query = function(table, conditions, index, options) {
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ describe("Node simple dynamo", function() {
     describe("Service invocation", function() {
 
     	SimpleDynamo = require('../index.js');
-		database = new SimpleDynamo({}, {
+		database = new SimpleDynamo({
 		    region: "eu-west-1",
 		    dynamodb: '2012-08-10'
 		});
@@ -50,7 +50,7 @@ describe("Node simple dynamo", function() {
 
 		it("should return a correct query object", function() {
 
-			database = new ddbriver({}, {
+			database = new ddbriver({
 			    region: "eu-west-1",
 			    dynamodb: '2012-08-10'
 			});
@@ -98,7 +98,7 @@ describe("Node simple dynamo", function() {
 
 		it("Should return the correct list", function() {
 
-			database = new ddbriver({}, {
+			database = new ddbriver({
 			    region: "eu-west-1",
 			    dynamodb: '2012-08-10'
 			});
@@ -144,7 +144,7 @@ describe("Node simple dynamo", function() {
 
 		it("Should return the correct list", function() {
 
-			database = new ddbriver({}, {
+			database = new ddbriver({
 			    region: "eu-west-1",
 			    dynamodb: '2012-08-10'
 			});
@@ -195,7 +195,7 @@ describe("Node simple dynamo", function() {
 
 		it("Should return the correct list", function(	) {
 
-			database = new ddbriver({}, {
+			database = new ddbriver({
 			    region: "eu-west-1",
 			    dynamodb: '2012-08-10'
 			});
@@ -253,7 +253,7 @@ describe("Node simple dynamo", function() {
 
 		it("Should return the correct list", function() {
 
-			database = new ddbriver({}, {
+			database = new ddbriver({
 			    region: "eu-west-1",
 			    dynamodb: '2012-08-10'
 			});


### PR DESCRIPTION
This is to avoid updating global AWS configuration when choosing the region.