### PR TITLE
impr: PD-9323 return last evaluated key when there is no pagination option

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,11 +179,19 @@ module.exports = function (dynamoDbOptions) {
               return paginate(data.LastEvaluatedKey);
             }
 
-            return items;
+            return items;            
           });
       };
 
       return paginate();
+    }
+
+    if (options && options.limit) {
+      params.Limit = options.limit
+    }
+
+    if (options && options.exclusiveStartKey) {
+      params.ExclusiveStartKey = options.exclusiveStartKey
     }
 
     return dynamodb
@@ -195,7 +203,17 @@ module.exports = function (dynamoDbOptions) {
           items.push(utils.deitemize(item));
         });
 
+        // return an object with the items and 
+        //last evaluated key if the option is specified.
+        if (options && options.getLastEvaluatedKey) {
+          return {
+            items,
+            lastEvaluatedKey: data.LastEvaluatedKey
+          }
+        }
+
         return items;
+       
       });
   };
 


### PR DESCRIPTION
### Issue Link:

https://cloudconformity.atlassian.net/browse/PD-9323

### What does it do?

Extends list to have a limit option for the number of items to scan, start from an exclusiveStartKey and returns the last evaluated key

#### Notes to reviewers

Please review with the related PR's

#### Related PR's

https://github.com/cloudconformity/entity-setting/pull/32
https://github.com/cloudconformity/service-setting/pull/186
https://github.com/cloudconformity/service-report-summary/pull/2